### PR TITLE
Removing extra parenthesis in the formula definition.

### DIFF
--- a/scripts/spreadsheet.py
+++ b/scripts/spreadsheet.py
@@ -30,7 +30,7 @@ def main():
         for row in csv_reader:
             previous_row_num = len(sheet.get_all_values())
             current_row_num = previous_row_num + 1
-            percentage_increase = "=ROUND(MINUS(B{},B{})/B{}, 2))".format(
+            percentage_increase = "=ROUND(MINUS(B{},B{})/B{}, 2)".format(
                 current_row_num, previous_row_num, previous_row_num)
             row.append(percentage_increase)
             print(row)


### PR DESCRIPTION
The extra parenthesis results in an error when the formula is resolved.

![Screenshot from 2019-06-22 18-02-24](https://user-images.githubusercontent.com/16665803/59966140-2d1ade00-9518-11e9-80b0-9781312dc493.png)
