### PR TITLE
Enable client to open ticket windows using the ticket links.

### DIFF
--- a/mind_your_stonks/bet_client.py
+++ b/mind_your_stonks/bet_client.py
@@ -57,6 +57,9 @@ class BetClient(object):
         self.driver.find_element_by_name("frmPassword").send_keys(self._password)
         self.driver.find_element_by_name("frmForceTerms").click()
         self.driver.find_element_by_name("submitted").click()
+        WebDriverWait(self.driver, TIMEOUT).unitl(
+            condition.url_to_be("https://www.bet.co.za/index.php/user/account/"))
+        self.web_setup.logger.info("Succesfully logged into %s", BET_URL)
 
     def sign_out(self):
         self.driver.find_element_by_xpath("//*[@id='block-logout']").click()

--- a/mind_your_stonks/bet_client.py
+++ b/mind_your_stonks/bet_client.py
@@ -2,7 +2,6 @@ import time
 from aenum import Constant
 from datetime import datetime
 
-from selenium.webdriver.firefox.options import Options
 from selenium.webdriver.common.by import By
 from selenium.webdriver.support import expected_conditions as condition
 from selenium.webdriver.support.select import Select

--- a/mind_your_stonks/bet_client.py
+++ b/mind_your_stonks/bet_client.py
@@ -206,6 +206,7 @@ class BetClient(object):
                 "//tr/td["+str(BetHistoryTableColumn.TICKET)+"]")
 
             for ticket in tickets:
+                self.web_setup.logger(f"Processing ticket {ticket.text}")
                 ticket_link = self.driver.find_element_by_link_text(ticket.text)
                 window_handles = self.driver.window_handles
                 betting_history_window = window_handles[0]

--- a/mind_your_stonks/bet_client.py
+++ b/mind_your_stonks/bet_client.py
@@ -125,7 +125,7 @@ class BetClient(object):
         # Click on the 'Go' button to filter bets
         form_filter.find_element_by_class_name("inputBtn").click()
         WebDriverWait(self.driver, TIMEOUT).unitl(
-            condition.visibility_of_element_located(By.CLASS_NAME, "stdTable"))
+            condition.presence_of_element_located(By.CLASS_NAME, "stdTable"))
 
     def _get_number_of_pages_for_table(self):
         # Pages can come in different forms
@@ -163,7 +163,7 @@ class BetClient(object):
                 page = pagination.find_element_by_link_text(f"{page_number}")
                 page.click()
                 WebDriverWait(self.driver, TIMEOUT).unitl(
-                    condition.visibility_of_element_located(By.CLASS_NAME, "stdTable"))
+                    condition.presence_of_element_located(By.CLASS_NAME, "stdTable"))
             
             # Get the table object
             table = self.driver.find_element_by_class_name("stdTable")
@@ -192,7 +192,7 @@ class BetClient(object):
                 page = pagination.find_element_by_link_text(f"{page_number}")
                 page.click()
                 WebDriverWait(self.driver, TIMEOUT).unitl(
-                    condition.visibility_of_element_located(By.CLASS_NAME, "stdTable"))
+                    condition.presence_of_element_located(By.CLASS_NAME, "stdTable"))
 
             # Get the table object
             table = self.driver.find_element_by_class_name("stdTable")

--- a/mind_your_stonks/bet_client.py
+++ b/mind_your_stonks/bet_client.py
@@ -162,7 +162,6 @@ class BetClient(object):
                 # Need to get the pagination element again or else raises
                 # StaleElementReferenceException
                 pagination = self.driver.find_element_by_class_name("pagination")
-                print("Page number: {}".format(page_number))
                 page = pagination.find_element_by_link_text('{}'.format(page_number))
                 page.click()
                 time.sleep(random.randint(2, 3))
@@ -181,6 +180,7 @@ class BetClient(object):
                 betting_history_window = self.driver.window_handles[0]
                 ticket_link.click()
                 time.sleep(random.randint(2, 3))
+                # TODO (kmadisa 06-09-2019) Extract information fromt the ticket.
                 self.driver.switch_to.window(betting_history_window)
 
         return betting_history

--- a/mind_your_stonks/bet_client.py
+++ b/mind_your_stonks/bet_client.py
@@ -148,6 +148,8 @@ class BetClient(object):
         
         return num_of_pages
 
+    # TODO (kmadisa 06-09-2019) Find a way to refactor the duplicate code inside
+    # the `compute_money_invested` and `export_betting_history_data` methods.
     def compute_money_invested(self):
         money_invested = 0.00
         number_of_pages = self._get_number_of_pages_for_table()

--- a/mind_your_stonks/bet_client.py
+++ b/mind_your_stonks/bet_client.py
@@ -19,6 +19,8 @@ TIMEOUT = 2.00
 
 # Betting History table columns
 # | Ticket | Event Date | Tournament | Event | Selection | Bet Type | Stake | Potential Win | Status |
+
+
 class BetHistoryTableColumn(Constant):
     (TICKET, EVENT_DATE, TOURNAMENT, EVENT, SELECTION, BET_TYPE,
      STAKE, POTENTIAL_WIN, STATUS)  = range(1, 10)

--- a/mind_your_stonks/bet_client.py
+++ b/mind_your_stonks/bet_client.py
@@ -1,3 +1,4 @@
+import time
 from aenum import Constant
 from datetime import datetime
 
@@ -132,7 +133,6 @@ class BetClient(object):
         # '' ==> means just one page
         # '12»' ==> means just two pages in total
         # '1234567»[12]' ==> means 12 pages in total
-        # 
         pagination = self.driver.find_element_by_class_name("pagination")
         pagination_text = pagination.text
         num_of_pages = 0

--- a/mind_your_stonks/bet_client.py
+++ b/mind_your_stonks/bet_client.py
@@ -81,7 +81,7 @@ class BetClient(object):
             condition.url_to_be(
                 "https://www.bet.co.za/index.php/betting/history/action/betHistory/"))
         self.web_setup.logger.info("Switched to the Betting History page.")
-    
+
     def goto_account_history(self):
         self.driver.find_element_by_link_text("My Account History").click()
         WebDriverWait(self.driver, TIMEOUT).until(
@@ -145,7 +145,7 @@ class BetClient(object):
         elif pagination_text.endswith("]"):
             # '1234567»[12]' -> 12
             num_of_pages = int(pagination_text.split("[")[-1].split("]")[0])
-        
+
         return num_of_pages
 
     # TODO (kmadisa 06-09-2019) Find a way to refactor the duplicate code inside
@@ -172,10 +172,10 @@ class BetClient(object):
             # Get all the rows on column number 7 (Stake)
             stakes = table.find_elements_by_xpath(
                 "//tr/td["+str(BetHistoryTableColumn.STAKE)+"]")
-        
+
             for stake in stakes:
                 money_invested += float(stake.text)
-        
+
         return money_invested
 
     def export_betting_history_data(self, month=str(BetMonth.ALL)):

--- a/mind_your_stonks/bet_client.py
+++ b/mind_your_stonks/bet_client.py
@@ -210,8 +210,7 @@ class BetClient(object):
                 window_handles = self.driver.window_handles
                 betting_history_window = window_handles[0]
                 ticket_link.click()
-                WebDriverWait(self.driver, TIMEOUT).unitl(
-                    condition.new_window_is_opened(window_handles))
+                time.sleep(TIMEOUT)
                 # TODO (kmadisa 06-09-2019) Extract information fromt the ticket.
                 self.driver.switch_to.window(betting_history_window)
 

--- a/mind_your_stonks/bet_client.py
+++ b/mind_your_stonks/bet_client.py
@@ -175,32 +175,12 @@ class BetClient(object):
             # difficult to split up (no unique delimiter).
             tickets = table.find_elements_by_xpath(
                 "//tr/td["+str(BetHistoryTableColumn.TICKET)+"]")
-            event_dates = table.find_elements_by_xpath(
-                "//tr/td["+str(BetHistoryTableColumn.EVENT_DATE)+"]")
-            tournaments = table.find_elements_by_xpath(
-                "//tr/td["+str(BetHistoryTableColumn.TOURNAMENT)+"]")
-            events = table.find_elements_by_xpath(
-                "//tr/td["+str(BetHistoryTableColumn.EVENT)+"]")
-            selections = table.find_elements_by_xpath(
-                "//tr/td["+str(BetHistoryTableColumn.SELECTION)+"]")
-            bet_types = table.find_elements_by_xpath(
-                "//tr/td["+str(BetHistoryTableColumn.BET_TYPE)+"]")
-            stakes = table.find_elements_by_xpath(
-                "//tr/td["+str(BetHistoryTableColumn.STAKE)+"]")
-            potential_wins = table.find_elements_by_xpath(
-                "//tr/td["+str(BetHistoryTableColumn.POTENTIAL_WIN)+"]")
-            statuses = table.find_elements_by_xpath(
-                "//tr/td["+str(BetHistoryTableColumn.STATUS)+"]")
 
-            for (ticket, event_date, tournament, event,
-                 selection, bet_type, stake, potential_win,
-                 status) in zip(tickets, event_dates, tournaments, events,
-                 selections, bet_types, stakes, potential_wins,
-                 statuses):
-                 betting_history.append([
-                     ticket.text, event_date.text, tournament.text,
-                     event.text, selection.text, bet_type.text, stake.text,
-                     potential_win.text, status.text
-                     ])
+            for ticket in tickets:
+                ticket_link = self.driver.find_element_by_link_text(ticket.text)
+                betting_history_window = self.driver.window_handles[0]
+                ticket_link.click()
+                time.sleep(random.randint(2, 3))
+                self.driver.switch_to.window(betting_history_window)
 
         return betting_history

--- a/mind_your_stonks/bet_client.py
+++ b/mind_your_stonks/bet_client.py
@@ -59,11 +59,11 @@ class BetClient(object):
         self.driver.find_element_by_name("submitted").click()
         WebDriverWait(self.driver, TIMEOUT).unitl(
             condition.url_to_be("https://www.bet.co.za/index.php/user/account/"))
-        self.web_setup.logger.info("Succesfully logged into %s", BET_URL)
+        self.web_setup.logger.info(f"Succesfully logged into {BET_URL}.")
 
     def sign_out(self):
         self.driver.find_element_by_xpath("//*[@id='block-logout']").click()
-        self.web_setup.logger.info("Succesfully logged out of %s", BET_URL)
+        self.web_setup.logger.info("Succesfully logged out of {BET_URL}.")
         self.web_setup.close_session()
 
     @property
@@ -111,19 +111,19 @@ class BetClient(object):
         selector = Select(form_filter.find_element_by_id("status"))
         # Select option in wager status dropdown
         selector.select_by_visible_text(status)
-        self.web_setup.logger.info("Filtering by wager status: %s.", status)
+        self.web_setup.logger.info(f"Filtering by wager status: {status}.")
 
         if month != BetMonth.LAST_7_DAYS:
             selector = Select(form_filter.find_element_by_class_name("date_range"))
             # Select option in month dropdown
             selector.select_by_visible_text(month)
-            self.web_setup.logger.info("Filtering by month: %s.", month)
+            self.web_setup.logger.info(f"Filtering by month: {month}.")
 
         if year != str(datetime.now().year):
             selector = Select(form_filter.find_element_by_class_name("year"))
             # Select option in year dropdown
             selector.select_by_visible_text(year)
-            self.web_setup.logger.info("Filtering by year: %s.", year)
+            self.web_setup.logger.info(f"Filtering by year: {year}.")
 
         # Click on the 'Go' button to filter bets
         form_filter.find_element_by_class_name("inputBtn").click()
@@ -158,12 +158,12 @@ class BetClient(object):
         last_page = number_of_pages + 1
 
         for page_number in range(first_page, last_page):
-            self.web_setup.logger.info("Computing stakes on page: %s.", page_number)
+            self.web_setup.logger.info(f"Computing stakes on page: {page_number}.")
             if page_number > first_page:
                 # Need to get the pagination element again or else raises
                 # StaleElementReferenceException
                 pagination = self.driver.find_element_by_class_name("pagination")
-                page = pagination.find_element_by_link_text('{}'.format(page_number))
+                page = pagination.find_element_by_link_text(f"{page_number}")
                 page.click()
                 WebDriverWait(self.driver, TIMEOUT).unitl(
                     condition.visibility_of_element_located(By.CLASS_NAME, "stdTable"))
@@ -187,12 +187,12 @@ class BetClient(object):
         last_page = number_of_pages + 1
 
         for page_number in range(first_page, last_page):
-            self.web_setup.logger.info("Computing stakes on page: %s.", page_number)
+            self.web_setup.logger.info(f"Computing stakes on page: {page_number}.")
             if page_number > first_page:
                 # Need to get the pagination element again or else raises
                 # StaleElementReferenceException
                 pagination = self.driver.find_element_by_class_name("pagination")
-                page = pagination.find_element_by_link_text('{}'.format(page_number))
+                page = pagination.find_element_by_link_text(f"{page_number}")
                 page.click()
                 WebDriverWait(self.driver, TIMEOUT).unitl(
                     condition.visibility_of_element_located(By.CLASS_NAME, "stdTable"))

--- a/mind_your_stonks/bet_client.py
+++ b/mind_your_stonks/bet_client.py
@@ -1,7 +1,4 @@
-import time
-import random
 from aenum import Constant
-
 from datetime import datetime
 
 from selenium.webdriver.firefox.options import Options

--- a/mind_your_stonks/bet_client.py
+++ b/mind_your_stonks/bet_client.py
@@ -5,12 +5,16 @@ from aenum import Constant
 from datetime import datetime
 
 from selenium.webdriver.firefox.options import Options
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as condition
 from selenium.webdriver.support.select import Select
+from selenium.webdriver.support.ui import WebDriverWait
 
 from mind_your_stonks.web_driver import WebDriverSetup
 
 
 BET_URL = "https://www.bet.co.za"
+TIMEOUT = 2.00
 
 # Solution for creating a set of constants found here
 # https://codereview.stackexchange.com/questions/193090/python-constant-class-different-enum-implementation
@@ -72,9 +76,15 @@ class BetClient(object):
 
     def goto_betting_history(self):
         self.driver.find_element_by_link_text("My Betting History").click()
+        WebDriverWait(self.driver, TIMEOUT).unitl(
+            condition.url_to_be(
+                "https://www.bet.co.za/index.php/betting/history/action/betHistory/"))
     
     def goto_account_history(self):
         self.driver.find_element_by_link_text("My Account History").click()
+        WebDriverWait(self.driver, TIMEOUT).unitl(
+            condition.url_to_be(
+                "https://www.bet.co.za/index.php/betting/history/action/translog/"))
 
     def filter_betting_history(self, status, month=BetMonth.LAST_7_DAYS,
                                year=str(datetime.now().year)):
@@ -108,6 +118,8 @@ class BetClient(object):
 
         # Click on the 'Go' button to filter bets
         form_filter.find_element_by_class_name("inputBtn").click()
+        WebDriverWait(self.driver, TIMEOUT).unitl(
+            condition.visibility_of_element_located(By.CLASS_NAME, "stdTable"))
 
     def _get_number_of_pages_for_table(self):
         # Pages can come in different forms
@@ -164,7 +176,8 @@ class BetClient(object):
                 pagination = self.driver.find_element_by_class_name("pagination")
                 page = pagination.find_element_by_link_text('{}'.format(page_number))
                 page.click()
-                time.sleep(random.randint(2, 3))
+                WebDriverWait(self.driver, TIMEOUT).unitl(
+                    condition.visibility_of_element_located(By.CLASS_NAME, "stdTable"))
 
             # Get the table object
             table = self.driver.find_element_by_class_name("stdTable")
@@ -177,9 +190,11 @@ class BetClient(object):
 
             for ticket in tickets:
                 ticket_link = self.driver.find_element_by_link_text(ticket.text)
-                betting_history_window = self.driver.window_handles[0]
+                window_handles = self.driver.window_handles
+                betting_history_window = window_handles[0]
                 ticket_link.click()
-                time.sleep(random.randint(2, 3))
+                WebDriverWait(self.driver, TIMEOUT).unitl(
+                    condition.new_window_is_opened(window_handles))
                 # TODO (kmadisa 06-09-2019) Extract information fromt the ticket.
                 self.driver.switch_to.window(betting_history_window)
 

--- a/mind_your_stonks/bet_client.py
+++ b/mind_your_stonks/bet_client.py
@@ -54,7 +54,7 @@ class BetClient(object):
         self.driver.find_element_by_name("frmPassword").send_keys(self._password)
         self.driver.find_element_by_name("frmForceTerms").click()
         self.driver.find_element_by_name("submitted").click()
-        WebDriverWait(self.driver, TIMEOUT).unitl(
+        WebDriverWait(self.driver, TIMEOUT).until(
             condition.url_to_be("https://www.bet.co.za/index.php/user/account/"))
         self.web_setup.logger.info(f"Succesfully logged into {BET_URL}.")
 
@@ -77,14 +77,14 @@ class BetClient(object):
 
     def goto_betting_history(self):
         self.driver.find_element_by_link_text("My Betting History").click()
-        WebDriverWait(self.driver, TIMEOUT).unitl(
+        WebDriverWait(self.driver, TIMEOUT).until(
             condition.url_to_be(
                 "https://www.bet.co.za/index.php/betting/history/action/betHistory/"))
         self.web_setup.logger.info("Switched to the Betting History page.")
     
     def goto_account_history(self):
         self.driver.find_element_by_link_text("My Account History").click()
-        WebDriverWait(self.driver, TIMEOUT).unitl(
+        WebDriverWait(self.driver, TIMEOUT).until(
             condition.url_to_be(
                 "https://www.bet.co.za/index.php/betting/history/action/translog/"))
         self.web_setup.logger.info("Switched to the Account History page.")
@@ -124,8 +124,8 @@ class BetClient(object):
 
         # Click on the 'Go' button to filter bets
         form_filter.find_element_by_class_name("inputBtn").click()
-        WebDriverWait(self.driver, TIMEOUT).unitl(
-            condition.presence_of_element_located(By.CLASS_NAME, "stdTable"))
+        WebDriverWait(self.driver, TIMEOUT).until(
+            condition.presence_of_element_located((By.CLASS_NAME, "stdTable")))
 
     def _get_number_of_pages_for_table(self):
         # Pages can come in different forms
@@ -164,9 +164,9 @@ class BetClient(object):
                 pagination = self.driver.find_element_by_class_name("pagination")
                 page = pagination.find_element_by_link_text(f"{page_number}")
                 page.click()
-                WebDriverWait(self.driver, TIMEOUT).unitl(
-                    condition.presence_of_element_located(By.CLASS_NAME, "stdTable"))
-            
+                WebDriverWait(self.driver, TIMEOUT).until(
+                    condition.presence_of_element_located((By.CLASS_NAME, "stdTable")))
+
             # Get the table object
             table = self.driver.find_element_by_class_name("stdTable")
             # Get all the rows on column number 7 (Stake)
@@ -193,8 +193,8 @@ class BetClient(object):
                 pagination = self.driver.find_element_by_class_name("pagination")
                 page = pagination.find_element_by_link_text(f"{page_number}")
                 page.click()
-                WebDriverWait(self.driver, TIMEOUT).unitl(
-                    condition.presence_of_element_located(By.CLASS_NAME, "stdTable"))
+                WebDriverWait(self.driver, TIMEOUT).until(
+                    condition.presence_of_element_located((By.CLASS_NAME, "stdTable")))
 
             # Get the table object
             table = self.driver.find_element_by_class_name("stdTable")

--- a/mind_your_stonks/bet_client.py
+++ b/mind_your_stonks/bet_client.py
@@ -83,12 +83,14 @@ class BetClient(object):
         WebDriverWait(self.driver, TIMEOUT).unitl(
             condition.url_to_be(
                 "https://www.bet.co.za/index.php/betting/history/action/betHistory/"))
+        self.web_setup.logger.info("Switched to the Betting History page.")
     
     def goto_account_history(self):
         self.driver.find_element_by_link_text("My Account History").click()
         WebDriverWait(self.driver, TIMEOUT).unitl(
             condition.url_to_be(
                 "https://www.bet.co.za/index.php/betting/history/action/translog/"))
+        self.web_setup.logger.info("Switched to the Account History page.")
 
     def filter_betting_history(self, status, month=BetMonth.LAST_7_DAYS,
                                year=str(datetime.now().year)):
@@ -109,16 +111,19 @@ class BetClient(object):
         selector = Select(form_filter.find_element_by_id("status"))
         # Select option in wager status dropdown
         selector.select_by_visible_text(status)
+        self.web_setup.logger.info("Filtering by wager status: %s.", status)
 
         if month != BetMonth.LAST_7_DAYS:
             selector = Select(form_filter.find_element_by_class_name("date_range"))
             # Select option in month dropdown
             selector.select_by_visible_text(month)
+            self.web_setup.logger.info("Filtering by month: %s.", month)
 
         if year != str(datetime.now().year):
             selector = Select(form_filter.find_element_by_class_name("year"))
             # Select option in year dropdown
             selector.select_by_visible_text(year)
+            self.web_setup.logger.info("Filtering by year: %s.", year)
 
         # Click on the 'Go' button to filter bets
         form_filter.find_element_by_class_name("inputBtn").click()
@@ -152,13 +157,14 @@ class BetClient(object):
         first_page = 1
         last_page = number_of_pages + 1
 
-        for page in range(first_page, last_page):
-            if page > first_page:
+        for page_number in range(first_page, last_page):
+            self.web_setup.logger.info("Computing stakes on page: %s.", page_number)
+            if page_number > first_page:
                 # Need to get the pagination element again or else raises
                 # StaleElementReferenceException
                 pagination = self.driver.find_element_by_class_name("pagination")
-                page_ = pagination.find_element_by_link_text('{}'.format(page))
-                page_.click()
+                page = pagination.find_element_by_link_text('{}'.format(page_number))
+                page.click()
                 WebDriverWait(self.driver, TIMEOUT).unitl(
                     condition.visibility_of_element_located(By.CLASS_NAME, "stdTable"))
             
@@ -181,6 +187,7 @@ class BetClient(object):
         last_page = number_of_pages + 1
 
         for page_number in range(first_page, last_page):
+            self.web_setup.logger.info("Computing stakes on page: %s.", page_number)
             if page_number > first_page:
                 # Need to get the pagination element again or else raises
                 # StaleElementReferenceException

--- a/mind_your_stonks/web_driver.py
+++ b/mind_your_stonks/web_driver.py
@@ -1,5 +1,3 @@
-import time
-import random
 import psutil
 
 from loguru import logger

--- a/mind_your_stonks/web_driver.py
+++ b/mind_your_stonks/web_driver.py
@@ -9,7 +9,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as condition
 
 
-TIMEOUT = 2.00
+TIMEOUT = 60.00
 
 
 class WebDriverSetup(object):
@@ -32,7 +32,7 @@ class WebDriverSetup(object):
         try:
             self.logger.debug(f"Navigating to {url}.")
             self.driver.get(url)
-            WebDriverWait(self.driver, TIMEOUT).until(condition.url_to_be(url))
+            self.driver.set_page_load_timeout(self._timeout)
             self.logger.debug(f"Successfully opened the url: {url}.")
         except TimeoutException:
             self.logger.exception("Timed-out while loading page.")

--- a/mind_your_stonks/web_driver.py
+++ b/mind_your_stonks/web_driver.py
@@ -1,7 +1,9 @@
 import psutil
+from psutil import NoSuchProcess
 
 from loguru import logger
 from selenium import webdriver
+from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.firefox.options import Options
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as condition
@@ -65,7 +67,7 @@ class WebDriverSetup(object):
                  for proc in psutil.process_iter()
                  if proc.name() == PROCNAME
             ]
-        except:
+        except NoSuchProcess:
             self.logger.debug(f"Process named {PROCNAME} process does not exist.")
 
         self.logger.info("Done...")

--- a/mind_your_stonks/web_driver.py
+++ b/mind_your_stonks/web_driver.py
@@ -4,7 +4,6 @@ import psutil
 
 from loguru import logger
 from selenium import webdriver
-from selenium.webdriver.common.by import By
 from selenium.webdriver.firefox.options import Options
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as condition

--- a/mind_your_stonks/web_driver.py
+++ b/mind_your_stonks/web_driver.py
@@ -34,7 +34,7 @@ class WebDriverSetup(object):
             self.driver.get(url)
             WebDriverWait(self.driver, TIMEOUT).until(condition.url_to_be(url))
             self.logger.debug(f"Successfully opened the url: {url}.")
-        except TimeoutException as te:
+        except TimeoutException:
             self.logger.exception("Timed-out while loading page.")
             self.close_session()
 

--- a/mind_your_stonks/web_driver.py
+++ b/mind_your_stonks/web_driver.py
@@ -5,8 +5,6 @@ from loguru import logger
 from selenium import webdriver
 from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.firefox.options import Options
-from selenium.webdriver.support.ui import WebDriverWait
-from selenium.webdriver.support import expected_conditions as condition
 
 
 TIMEOUT = 60.00


### PR DESCRIPTION
This allows the agent to be able to click on the hyperlinks associated with the betting ticket ID thus allowing the agent to retrieve more data related to the bet.

This is useful when handling bet accumulators. See screenshot attached below.

![stonks](https://user-images.githubusercontent.com/16665803/68244235-0cfa4000-001d-11ea-991e-ef64c15a4ad9.jpg)
